### PR TITLE
fix: Stop reading JWT from WebSocket query string (issue #9)

### DIFF
--- a/fastapi_keycloak_rbac/backend.py
+++ b/fastapi_keycloak_rbac/backend.py
@@ -11,7 +11,6 @@ corresponding extras are installed and configured.
 import logging
 import time
 from typing import Any
-from urllib.parse import parse_qsl
 
 from fastapi.security.utils import get_authorization_scheme_param
 from jwcrypto.jwt import JWTExpired  # type: ignore[import-untyped]
@@ -106,21 +105,24 @@ class AuthBackend(AuthenticationBackend):
 
         Returns:
             ``(AuthCredentials, UserModel)`` on success, ``None`` for excluded
-            paths (HTTP only).
+            HTTP paths or any WebSocket connection. WebSocket auth is handled
+            via a first-message handshake inside the WS handler (RFC 9700 §4.3.2).
 
         Raises:
             AuthenticationError: On token expiry, invalid credentials, or
-                                 decode errors.
+                                 decode errors (HTTP only).
         """
         logger.debug("Request type -> %s", conn.scope["type"])
 
         if conn.scope["type"] == "websocket":
-            qs = dict(parse_qsl(conn.scope["query_string"].decode("utf8")))
-            auth_header = qs.get("Authorization", "")
-        else:
-            if self.settings.excluded_paths_pattern.match(conn.url.path):
-                return None
-            auth_header = conn.headers.get("authorization", "")
+            # Token is NOT read from the query string — doing so exposes it in
+            # access logs, browser history, and proxy caches (RFC 9700 §4.3.2).
+            # Auth is handled via first-message handshake inside the WS handler.
+            return None
+
+        if self.settings.excluded_paths_pattern.match(conn.url.path):
+            return None
+        auth_header = conn.headers.get("authorization", "")
 
         _, access_token = get_authorization_scheme_param(auth_header)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -148,28 +148,37 @@ class TestAuthenticateHTTP:
 
 class TestAuthenticateWebSocket:
     @pytest.mark.asyncio
-    async def test_extracts_token_from_query_string(
-        self, backend: AuthBackend, mock_manager: KeycloakManager
-    ) -> None:
-        mock_manager.decode_token = AsyncMock(return_value=SAMPLE_CLAIMS)
-        conn = make_ws_conn("mytoken")
+    async def test_websocket_upgrade_returns_none(self, backend: AuthBackend) -> None:
+        """AuthBackend must return None for any WS connection.
 
+        Token auth is handled via first-message handshake in the WS handler,
+        not at the HTTP upgrade level (RFC 9700 §4.3.2).
+        """
+        conn = make_ws_conn("mytoken")
         result = await backend.authenticate(conn)
 
-        assert result is not None
-        _, user = result
-        assert user.username == "testuser"
-        mock_manager.decode_token.assert_called_once_with("mytoken")
+        assert result is None
 
     @pytest.mark.asyncio
-    async def test_ws_does_not_check_excluded_paths(
-        self, backend: AuthBackend, mock_manager: KeycloakManager
+    async def test_websocket_returns_none_regardless_of_query_params(
+        self, backend: AuthBackend
     ) -> None:
-        mock_manager.decode_token = AsyncMock(return_value=SAMPLE_CLAIMS)
-        # WebSocket with a "health" path — should still authenticate
-        qs = b"Authorization=Bearer+mytoken"
+        """WS connections return None even if a token is in the query string."""
         conn = MagicMock()
-        conn.scope = {"type": "websocket", "query_string": qs}
+        conn.scope = {"type": "websocket", "query_string": b"Authorization=Bearer+token"}
 
         result = await backend.authenticate(conn)
-        assert result is not None
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_websocket_returns_none_with_empty_query_string(
+        self, backend: AuthBackend
+    ) -> None:
+        """WS connections return None even with no query params at all."""
+        conn = MagicMock()
+        conn.scope = {"type": "websocket", "query_string": b""}
+
+        result = await backend.authenticate(conn)
+
+        assert result is None


### PR DESCRIPTION
## Summary

- `AuthBackend.authenticate()` now returns `None` for all WebSocket connections instead of extracting the token from the `Authorization` query parameter
- Eliminates JWT token exposure in access logs, browser history, and proxy caches (RFC 9700 §4.3.2)
- Removes unused `parse_qsl` import
- Old query-param WS tests replaced with 3 tests confirming `None` return for any WS connection

## Why

Passing the JWT in the URL (`/web?Authorization=Bearer+<token>`) causes the raw token to appear in uvicorn/Traefik/Nginx access logs, browser history, and proxy caches. This is explicitly flagged in the OAuth 2.0 Security BCP.

## Paired with

fastapi-http-websocket #191 — adds first-message auth handshake in the WS handler that performs token validation after connection acceptance.

## Test plan

- [x] 10/10 backend tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)