### PR TITLE
fix: raise ValueError when require_roles() called with no roles

### DIFF
--- a/fastapi_keycloak_rbac/__init__.py
+++ b/fastapi_keycloak_rbac/__init__.py
@@ -12,7 +12,7 @@ __version__ = "0.2.1"
 
 from fastapi_keycloak_rbac.backend import AuthBackend
 from fastapi_keycloak_rbac.config import KeycloakAuthSettings, get_settings
-from fastapi_keycloak_rbac.dependencies import require_roles
+from fastapi_keycloak_rbac.dependencies import require_authenticated, require_roles
 from fastapi_keycloak_rbac.exceptions import (
     AuthenticationError,
     AuthorizationError,
@@ -52,4 +52,5 @@ __all__ = [
     "rbac_manager",
     "AuthBackend",
     "require_roles",
+    "require_authenticated",
 ]

--- a/fastapi_keycloak_rbac/dependencies.py
+++ b/fastapi_keycloak_rbac/dependencies.py
@@ -24,6 +24,7 @@ def require_roles(*roles: str) -> Callable[[Request], Awaitable[None]]:
         An async dependency function for use with ``Depends()``.
 
     Raises:
+        ValueError: At decoration time if no roles are provided.
         HTTPException: 401 if not authenticated, 403 if missing roles.
 
     Example::
@@ -41,3 +42,32 @@ def require_roles(*roles: str) -> Callable[[Request], Awaitable[None]]:
             return {"authors": []}
     """
     return rbac_manager.require_roles(*roles)
+
+
+def require_authenticated() -> Callable[[Request], Awaitable[None]]:
+    """
+    Create a FastAPI dependency that requires only authentication (no specific roles).
+
+    Convenience wrapper around ``rbac_manager.require_authenticated()``.
+
+    Returns:
+        An async dependency function for use with ``Depends()``.
+
+    Raises:
+        HTTPException: 401 if not authenticated.
+
+    Example::
+
+        from fastapi import APIRouter, Depends
+        from fastapi_keycloak_rbac.dependencies import require_authenticated
+
+        router = APIRouter()
+
+        @router.get(
+            "/profile",
+            dependencies=[Depends(require_authenticated())],
+        )
+        async def get_profile():
+            return {"profile": {}}
+    """
+    return rbac_manager.require_authenticated()

--- a/fastapi_keycloak_rbac/rbac.py
+++ b/fastapi_keycloak_rbac/rbac.py
@@ -106,6 +106,8 @@ class RBACManager:
             An async dependency function for use with ``Depends()``.
 
         Raises:
+            ValueError: At decoration time if no roles are provided. Use
+                ``require_authenticated()`` for auth-only enforcement.
             HTTPException: 401 if user is not authenticated.
             HTTPException: 403 if user lacks required roles.
 
@@ -118,6 +120,11 @@ class RBACManager:
             async def get_reports():
                 ...
         """
+        if not roles:
+            raise ValueError(
+                "require_roles() called with no roles. "
+                "Use require_authenticated() for auth-only enforcement."
+            )
 
         async def check_roles(request: Request) -> None:
             if isinstance(request.user, UnauthenticatedUser) or not request.user:
@@ -149,6 +156,38 @@ class RBACManager:
                 )
 
         return check_roles
+
+    def require_authenticated(self) -> Callable[[Request], Awaitable[None]]:
+        """
+        Create a FastAPI dependency that requires only authentication (no specific roles).
+
+        Use this instead of ``require_roles()`` when any authenticated user
+        should be allowed access.
+
+        Returns:
+            An async dependency function for use with ``Depends()``.
+
+        Raises:
+            HTTPException: 401 if user is not authenticated.
+
+        Example::
+
+            @router.get(
+                "/profile",
+                dependencies=[Depends(rbac_manager.require_authenticated())],
+            )
+            async def get_profile():
+                ...
+        """
+
+        async def check_authenticated(request: Request) -> None:
+            if isinstance(request.user, UnauthenticatedUser) or not request.user:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Authentication required",
+                )
+
+        return check_authenticated
 
 
 # Module-level singleton instance

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi import HTTPException
 from starlette.authentication import UnauthenticatedUser
 
-from fastapi_keycloak_rbac.dependencies import require_roles
+from fastapi_keycloak_rbac.dependencies import require_authenticated, require_roles
 from fastapi_keycloak_rbac.models import UserModel
 
 SAMPLE_CLAIMS = {
@@ -60,13 +60,30 @@ class TestRequireRoles:
 
         assert exc_info.value.status_code == 401
 
+    def test_raises_value_error_when_no_roles_given(self) -> None:
+        with pytest.raises(ValueError, match="require_roles\\(\\) called with no roles"):
+            require_roles()
+
+
+class TestRequireAuthenticated:
     @pytest.mark.asyncio
-    async def test_grants_access_with_no_roles_required(self, user: UserModel) -> None:
+    async def test_grants_authenticated_user(self, user: UserModel) -> None:
         request = MagicMock()
         request.user = user
 
-        dep = require_roles()
+        dep = require_authenticated()
         await dep(request)  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_raises_401_when_unauthenticated(self) -> None:
+        request = MagicMock()
+        request.user = UnauthenticatedUser()
+
+        dep = require_authenticated()
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request)
+
+        assert exc_info.value.status_code == 401
 
     @pytest.mark.asyncio
     async def test_requires_all_roles(self, user: UserModel) -> None:

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -108,13 +108,32 @@ class TestRequireRoles:
 
         assert exc_info.value.status_code == 401
 
+    def test_raises_value_error_when_no_roles_given(self, rbac: RBACManager) -> None:
+        with pytest.raises(ValueError, match="require_roles\\(\\) called with no roles"):
+            rbac.require_roles()
+
     @pytest.mark.asyncio
-    async def test_grants_when_no_roles_required(self, rbac: RBACManager, user: UserModel) -> None:
+    async def test_require_authenticated_grants_authenticated_user(
+        self, rbac: RBACManager, user: UserModel
+    ) -> None:
         request = MagicMock()
         request.user = user
 
-        dep = rbac.require_roles()
+        dep = rbac.require_authenticated()
         await dep(request)  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_require_authenticated_raises_401_when_unauthenticated(
+        self, rbac: RBACManager
+    ) -> None:
+        request = MagicMock()
+        request.user = UnauthenticatedUser()
+
+        dep = rbac.require_authenticated()
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request)
+
+        assert exc_info.value.status_code == 401
 
     @pytest.mark.asyncio
     async def test_requires_all_roles(self, rbac: RBACManager, user: UserModel) -> None:


### PR DESCRIPTION
## Summary

- Fixes #14 — `require_roles()` called with no arguments now raises `ValueError` at decoration time, preventing silent allow-all for authenticated users.
- Added `require_authenticated()` to `RBACManager` and exported as a convenience function for explicit auth-only enforcement.

## Test plan

- [x] `test_raises_value_error_when_no_roles_given` — verifies the guard fires
- [x] `test_require_authenticated_grants_authenticated_user` — verifies the new helper works
- [x] `test_require_authenticated_raises_401_when_unauthenticated` — verifies 401 on unauth
- [x] All 25 tests pass, `rbac.py` and `dependencies.py` at 100% coverage